### PR TITLE
updating import to match typechain folder structure

### DIFF
--- a/test/factory/Factory.ts
+++ b/test/factory/Factory.ts
@@ -3,8 +3,8 @@ import type { Artifact } from "hardhat/types";
 import type { SignerWithAddress } from "@nomiclabs/hardhat-ethers/dist/src/signer-with-address";
 
 import type { AirbroFactory } from "../../src/types/contracts/AirbroFactory";
-import type { TestNftCollection } from "../../src/types/contracts/TestNftCollection";
-import type { TestToken } from "../../src/types/contracts/TestToken";
+import type { TestNftCollection } from "../../src/types/contracts/mocks/TestNftCollection";
+import type { TestToken } from "../../src/types/contracts/mocks/TestToken";
 import { Signers } from "../types";
 import { shouldBehaveLikeFactory } from "./Factory.behavior";
 


### PR DESCRIPTION
Cloning current master branch caused the following errorr:

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/56925545/173637655-0e505737-5666-4e41-bd34-427c760d3841.png">

This PR should fix it